### PR TITLE
Rename 'async' argument in order to support Python 3.7

### DIFF
--- a/momoko/connection.py
+++ b/momoko/connection.py
@@ -414,7 +414,7 @@ class Pool(object):
         See :py:meth:`momoko.Connection.mogrify` for documentation about the
         parameters.
         """
-        return self._operate(Connection.mogrify, args, kwargs, async=False)
+        return self._operate(Connection.mogrify, args, kwargs, _async=False)
 
     def register_hstore(self, *args, **kwargs):
         """
@@ -451,7 +451,7 @@ class Pool(object):
         self.conns.empty()
         self.closed = True
 
-    def _operate(self, method, args=(), kwargs=None, async=True, keep=False, connection=None):
+    def _operate(self, method, args=(), kwargs=None, _async=True, keep=False, connection=None):
         kwargs = kwargs or {}
         future = Future()
 
@@ -473,7 +473,7 @@ class Pool(object):
                 log.debug("Method failed synchronously")
                 return self._retry(retry, when_available, conn, keep, future)
 
-            if not async:
+            if not _async:
                 future.set_result(future_or_result)
                 if not keep:
                     self.putconn(conn)
@@ -667,7 +667,7 @@ class Connection(object):
         Initiate asynchronous connect.
         Returns future that resolves to this connection object.
         """
-        kwargs = {"async": True}
+        kwargs = {"_async": True}
         if self.connection_factory:
             kwargs["connection_factory"] = self.connection_factory
         if self.cursor_factory:


### PR DESCRIPTION
Since 'async' is now reserved keyword, we need to rename it.